### PR TITLE
adding support for other HTTP methods in sendTo

### DIFF
--- a/filedrop.js
+++ b/filedrop.js
@@ -1919,19 +1919,19 @@ window.fd = window.fd || {}
     // abort it (unless it's finished) and start anew.
     //
     //? sendTo('http://my.host/upload.php?var=foo&var2=123')
-    self.sendTo = function (url) {
+    self.sendTo = function (url, options) {
       if (window.FileReader) {
         // Using Firefox FileAPI.
         var reader = new FileReader
 
-        reader.onload = function (e) { self.sendDataReadyTo(url, e) }
+        reader.onload = function (e) { self.sendDataReadyTo(url, e, options) }
         reader.onerror = function (e) { global.callAllOfObject(self, 'error', [e]) }
 
         var func = reader.readAsBinaryString ? 'readAsBinaryString' : 'readAsArrayBuffer'
         reader[func](self.nativeFile)
       } else {
         // Using Chrome/Safari file API.
-        self.sendDataReadyTo(url)
+        self.sendDataReadyTo(url, undefined, options)
       }
 
       return self
@@ -1941,13 +1941,13 @@ window.fd = window.fd || {}
     // upload. For FileAPI (Firefox) gets called on readAsBinaryString() or
     // readAsArrayBuffer() onload event; for Safari/early Chrome it's called
     // immediately and gets passed the native file object itself.
-    self.sendDataReadyTo = function (url, e) {
+    self.sendDataReadyTo = function (url, e, options) {
       self.abort()
 
       self.xhr = global.newXHR()
       self.hookXHR(self.xhr)
 
-      self.xhr.open('POST', url, true)
+      self.xhr.open((options && options.method) || 'POST', url, true)
       // Missing in IE.
       self.xhr.overrideMimeType && self.xhr.overrideMimeType('application/octet-stream')
       self.xhr.setRequestHeader('Content-Type', 'application/octet-stream')


### PR DESCRIPTION
**tl; dr: I added an `options` object to `sendTo` and `sendDataReadyTo` which allows for specifying a method other than `POST`**

Thanks for the library!
## my problem

I am using [jquery.dav](sandro-pasquali/jquery.dav) to work with files on a WebDAV server (i.e. SharePoint). I have limited visibility into the server permissions, and my files can be large, so my approach is to "fail fast":
- try to create a file (with `PUT`) 
  - react if it fails
- `PUT` the file contents (replacing the empty contents)

At first, I tried to use `file.readData`, and put the content up myself, but was getting poor results with binary files... it is likely I was using `readData` incorrectly, or don't understand how to use the File API. Further, for large files, I'd like to avoid reading the data into memory unless absolutely necessary.
## my hack

However, hacking the filedrop source directly to use `PUT` solved my problems, for both text files and binary files, so I went ahead and monkeypatched `sendDataReadyTo` in my code to do what I want, but would like to see this option as part of the filedrop itself, if possible.

However, having only started using filedrop, I am not sure of the right way to add this to the API, since `POST` is specified as part of the `xhr.open` method, and cannot be overridden with `File.event('xhrSetup')` or `File.hookXHR`. The easiest is probably to just add `method` argument to `.sendTo` (and therefore `.sendDataReadyTo`).
## my solution

This PR takes a somewhat-more liberal position, and adds an `options` object to the key methods... it looks like only `async`, `username` and `password` would be used otherwise in this exact way, and those are unlikely to be very useful, but perhaps there are other possibilities I haven't thought of.
## testing

I notice that `sendTo` does not appear in the test suite. I could support setting up a `.travis.yml` to add some testing against a WebDAV server (I use [WsgiDav](https://github.com/mar10/wsgidav) for automated testing), if that would help get this feature added.
## related

a successful `PUT` is returning a `204 No Content`, for which I am having to use

``` .js
file.event("error", function(xhr){
  return [xhr.status === 204 ? success : fail](xhr);
})
```

Which seems a bit odd, but I am not sure how much HTTP-fu needs to be baked in... perhaps another day...

Thanks again!
