### PR TITLE
* uses local type instead of application/octet-stream

### DIFF
--- a/filedrop.js
+++ b/filedrop.js
@@ -2034,8 +2034,8 @@ window.fd = window.fd || {}
 
       self.xhr.open(opt.method, opt.url, true)
       // Missing in IE.
-      self.xhr.overrideMimeType && self.xhr.overrideMimeType('application/octet-stream')
-      self.xhr.setRequestHeader('Content-Type', 'application/octet-stream')
+      self.xhr.overrideMimeType && self.xhr.overrideMimeType(self.type)
+      self.xhr.setRequestHeader('Content-Type', self.type)
 
       if (opt.extraHeaders) {
         self.xhr.setRequestHeader('X-File-Name', encodeURIComponent(self.name))


### PR DESCRIPTION
At server-side, Content type always come up with 'application/octet-stream'. Would be nice (useful?) to copy across the local type.
